### PR TITLE
Add Basic Cancel method

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -234,6 +234,24 @@ defmodule GenRMQ.Consumer do
   end
 
   @doc """
+  Cancels the consumer
+
+  `module` - callback module implementing `GenRMQ.Consumer` behaviour
+  `consumer_tag` - identifier for the consumer, valid within the current channel
+  """
+  @spec cancel(module :: module(), consumer_tag :: String.t()) :: {:ok, String.t()}
+  def cancel(module, consumer_tag) do
+    channel = get_channel(module)
+    Basic.cancel(channel, consumer_tag)
+  end
+
+  @spec get_channel(module :: module()) :: Channel.t()
+  defp get_channel(module) do
+    state = GenServer.call(module, {:get_genserver_state})
+    state.in
+  end
+
+  @doc """
   Requeues / rejects given message
 
   `message` - `GenRMQ.Message` struct
@@ -272,6 +290,12 @@ defmodule GenRMQ.Consumer do
   @impl GenServer
   def handle_call({:recover, requeue}, _from, %{in: channel} = state) do
     {:reply, Basic.recover(channel, requeue: requeue), state}
+  end
+
+  @doc false
+  @impl GenServer
+  def handle_call({:get_genserver_state}, _from, state) do
+    {:reply, state, state}
   end
 
   @doc false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Stops the given consumer from consuming.

## Description
<!--- Describe your changes in detail -->

This method cancels a consumer. This does not affect already delivered messages, but it does mean the server will not send any more messages for that consumer. The client may receive an arbitrary number of messages in between sending the cancel method and receiving the reply.

<!--- Why is this change required? What problem does it solve? -->

The cancel method can be used to detach the consumer when SIGTERM signal is received from Kubernetes.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->

```
GenRMQ.Consumer.cancel(%{module: __MODULE__, consumer_tag: consumer_tag()})
```

<!--- Describe any manual or special tests you have done -->

<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [x] I have added unit tests to cover my changes.
- [x] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [x] I have updated the documentation accordingly
